### PR TITLE
Made grid items draggable and rearrangeable

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,39 +52,39 @@
                 <span class="w-skills"></span>
             </div>
             <div class="w-grid-sub">
-                <div class="w">
+                <div id="slot1" class="w">
                     <button id="wp1" class="grid-input" data-options="weapons" tabindex="13"></button>
                     <span class="w-skills"></span>
                 </div>
-                <div class="w">
+                <div id="slot2" class="w">
                     <button id="wp2" class="grid-input" data-options="weapons" tabindex="14"></button>
                     <span class="w-skills"></span>
                 </div>
-                <div class="w">
+                <div id="slot3" class="w">
                     <button id="wp3" class="grid-input" data-options="weapons" tabindex="15"></button>
                     <span class="w-skills"></span>
                 </div>
-                <div class="w">
+                <div id="slot4" class="w">
                     <button id="wp4" class="grid-input" data-options="weapons" tabindex="16"></button>
                     <span class="w-skills"></span>
                 </div>
-                <div class="w">
+                <div id="slot5" class="w">
                     <button id="wp5" class="grid-input" data-options="weapons" tabindex="17"></button>
                     <span class="w-skills"></span>
                 </div>
-                <div class="w">
+                <div id="slot6" class="w">
                     <button id="wp6" class="grid-input" data-options="weapons" tabindex=18></button>
                     <span class="w-skills"></span>
                 </div>
-                <div class="w">
+                <div id="slot7" class="w">
                     <button id="wp7" class="grid-input" data-options="weapons" tabindex="19"></button>
                     <span class="w-skills"></span>
                 </div>
-                <div class="w">
+                <div id="slot8" class="w">
                     <button id="wp8" class="grid-input" data-options="weapons" tabindex="20"></button>
                     <span class="w-skills"></span>
                 </div>
-                <div class="w">
+                <div id="slot9" class="w">
                     <button id="wp9" class="grid-input" data-options="weapons" tabindex="21"></button>
                     <span class="w-skills"></span>
                 </div>
@@ -92,15 +92,15 @@
         </div>
         <div id="weapon-grid-extra">
             <div class="w-grid-sub">
-                <div class="w">
+                <div id="slot10" class="w">
                     <button id="wp10" class="grid-input" data-options="weapons" tabindex="29"></button>
                     <span class="w-skills"></span>
                 </div>
-                <div class="w">
+                <div id="slot11" class="w">
                     <button id="wp11" class="grid-input" data-options="weapons" tabindex="30"></button>
                     <span class="w-skills"></span>
                 </div>
-                <div class="w">
+                <div id="slot12" class="w">
                     <button id="wp12" class="grid-input" data-options="weapons" tabindex="31"></button>
                     <span class="w-skills"></span>
                 </div>

--- a/index.html
+++ b/index.html
@@ -7,19 +7,21 @@
     <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
     <title>Granblue Grid Maker</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="sortable.js"></script> 
     <script src="main.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
 </head>
 
 <body>
     <div id="team-spread">
         <div class="team-container">
             <div class="team-members" style="left:10px;">
-                <button id="mc" class="grid-input" data-options="classes" tabindex="1"></button>
+                <button id="mc" class="grid-input no-drag" data-options="classes" tabindex="1"></button>
                 <button id="char1" class="grid-input" data-options="characters" tabindex="2"></button>
                 <button id="char2" class="grid-input" data-options="characters" tabindex="3"></button>
                 <button id="char3" class="grid-input" data-options="characters" tabindex="4"></button>
             </div>
-            <div class="team-members" style="right:10px;">
+            <div class="team-members sub-members" style="right:10px;">
                 <button id="char4" class="grid-input" data-options="characters" tabindex="5"></button>
                 <button id="char5" class="grid-input" data-options="characters" tabindex="6"></button>
             </div>

--- a/main.js
+++ b/main.js
@@ -257,6 +257,9 @@ window.onload = async (e) => {
 
     // Make character grid elements draggable
     InitTeamContainer()
+
+    // Make summon grid elements draggable
+    InitSummonsContainer();
 };
 
 const optionSets = {

--- a/main.js
+++ b/main.js
@@ -254,6 +254,9 @@ window.onload = async (e) => {
         }
     }
     setupButtonSearch();
+
+    // Make character grid elements draggable
+    InitTeamContainer()
 };
 
 const optionSets = {

--- a/main.js
+++ b/main.js
@@ -260,6 +260,9 @@ window.onload = async (e) => {
 
     // Make summon grid elements draggable
     InitSummonsContainer();
+
+    // Make weapon grid elements draggable
+    InitWeaponsContainer()
 };
 
 const optionSets = {

--- a/sortable.js
+++ b/sortable.js
@@ -1,10 +1,9 @@
-function NewSortableSwapContainer(container, draggable, group, onMove, onEnd) {
+function NewSortableSwapContainer(container, draggable, onMove, onEnd) {
     return new Sortable(container, {
         swap: true,
         animation: 150,
         ghostClass: "sortable-ghost",
         draggable: draggable,
-        group: group,
         onMove: (e) => {
             return onMove(e);
         },
@@ -18,7 +17,7 @@ function InitTeamContainer() {
     const teamList = document.querySelector(".team-members")
     const subMemberList = document.querySelector(".sub-members")
 
-    NewSortableSwapContainer(teamList, "button:not(.no-drag)", "", function(e){
+    NewSortableSwapContainer(teamList, "button:not(.no-drag)", function(e){
         // Disable swapping for character grid-inputs that are not filled
         // This is necessary to avoid a bug where the Wikitext duplicates a character if moved to an empty grid slot
         const target = e.related;
@@ -59,7 +58,7 @@ function InitTeamContainer() {
         }
     });
 
-    NewSortableSwapContainer(subMemberList, "button", "", function(e){
+    NewSortableSwapContainer(subMemberList, "button", function(e){
         // Disable swapping for character grid-inputs that are not filled
         // This is necessary to avoid a bug where the Wikitext duplicates a character if moved to an empty grid slot
         const target = e.related;
@@ -80,6 +79,101 @@ function InitTeamContainer() {
 
             if (e.newIndex == 1) {
                 swappedElement = document.querySelector("#char5")
+            }
+
+            const draggedID = draggedElement.id;
+            const swappedID = swappedElement.id;
+
+            // Swap IDs
+            draggedElement.id = swappedID;
+            swappedElement.id = draggedID;
+
+            if (teamData[draggedID]) {
+                const tempData = {...teamData}
+                Object.keys(teamData).forEach(key => {
+                    // Find all keys that start with dragged character's ID (ex: char1)
+                    if (key.startsWith(draggedID)) {
+                    // Swap the dragged character's data with the swapped character's data
+                        teamData[swappedID + key.substring(draggedID.length)] = tempData[key]
+                    }
+
+                    // Find all keys that start with swapped character's ID (ex: char1)
+                    if (key.startsWith(swappedID)) {
+                        // Swap the swapped character's data with the dragged character's data
+                        teamData[draggedID + key.substring(swappedID.length)] = tempData[key];
+                    }
+                })
+            }
+        }
+    });
+}
+
+function InitSummonsContainer() {
+    const summonsList = document.querySelector(".callable-summons");
+    const subSummonsList = document.querySelector(".sub-summons");
+
+    NewSortableSwapContainer(summonsList, "button", function(e) {
+        // Disable swapping for summon grid-inputs that are not filled
+        // This is necessary to avoid a bug where the Wikitext duplicates a summon if moved to an empty grid slot
+        const target = e.related;
+
+        if (!teamData[target.id]) {
+            return false;
+        }
+
+        return true
+    }, function(e) {
+         if (e.oldIndex != e.newIndex) {
+            const draggedElement = e.item
+            const swappedElement = document.querySelector(`#s${e.newIndex + 1}`)
+
+            const draggedID = draggedElement.id;
+            const swappedID = swappedElement.id;
+
+            // Swap IDs
+            draggedElement.id = swappedID;
+            swappedElement.id = draggedID;
+
+            if (teamData[draggedID]) {
+                const tempData = {...teamData}
+                Object.keys(teamData).forEach(key => {
+                    // Find all keys that start with dragged character's ID (ex: char1)
+                    if (key.startsWith(draggedID)) {
+                    // Swap the dragged character's data with the swapped character's data
+                        teamData[swappedID + key.substring(draggedID.length)] = tempData[key]
+                    }
+
+                    // Find all keys that start with swapped character's ID (ex: char1)
+                    if (key.startsWith(swappedID)) {
+                        // Swap the swapped character's data with the dragged character's data
+                        teamData[draggedID + key.substring(swappedID.length)] = tempData[key];
+                    }
+                })
+            }
+        }
+    });
+
+    NewSortableSwapContainer(subSummonsList, "button", function(e) {
+        // Disable swapping for summon grid-inputs that are not filled
+        // This is necessary to avoid a bug where the Wikitext duplicates a summon if moved to an empty grid slot
+        const target = e.related;
+
+        if (!teamData[target.id]) {
+            return false;
+        }
+
+        return true
+    }, function(e) {
+       if (e.oldIndex != e.newIndex) {
+            const draggedElement = e.item
+            let swappedElement
+            
+            if (e.newIndex == 0) {
+                swappedElement = document.querySelector("#s-sub1")
+            }
+
+            if (e.newIndex == 1) {
+                swappedElement = document.querySelector("#s-sub2")
             }
 
             const draggedID = draggedElement.id;

--- a/sortable.js
+++ b/sortable.js
@@ -1,0 +1,110 @@
+function NewSortableSwapContainer(container, draggable, group, onMove, onEnd) {
+    return new Sortable(container, {
+        swap: true,
+        animation: 150,
+        ghostClass: "sortable-ghost",
+        draggable: draggable,
+        group: group,
+        onMove: (e) => {
+            return onMove(e);
+        },
+        onEnd: (e) => {
+           return onEnd(e);
+        }
+    });
+}
+
+function InitTeamContainer() {
+    const teamList = document.querySelector(".team-members")
+    const subMemberList = document.querySelector(".sub-members")
+
+    NewSortableSwapContainer(teamList, "button:not(.no-drag)", "", function(e){
+        // Disable swapping for character grid-inputs that are not filled
+        // This is necessary to avoid a bug where the Wikitext duplicates a character if moved to an empty grid slot
+        const target = e.related;
+
+        if (!teamData[target.id]) {
+            return false;
+        }
+
+        return true
+    }, function(e) {
+        if (e.oldIndex != e.newIndex) {
+            const draggedElement = e.item
+            const swappedElement = document.querySelector(`#char${e.newIndex}`)
+
+            const draggedID = draggedElement.id;
+            const swappedID = swappedElement.id;
+
+            // Swap IDs
+            draggedElement.id = swappedID;
+            swappedElement.id = draggedID;
+
+            if (teamData[draggedID]) {
+                const tempData = {...teamData}
+                Object.keys(teamData).forEach(key => {
+                    // Find all keys that start with dragged character's ID (ex: char1)
+                    if (key.startsWith(draggedID)) {
+                    // Swap the dragged character's data with the swapped character's data
+                        teamData[swappedID + key.substring(draggedID.length)] = tempData[key]
+                    }
+
+                    // Find all keys that start with swapped character's ID (ex: char1)
+                    if (key.startsWith(swappedID)) {
+                        // Swap the swapped character's data with the dragged character's data
+                        teamData[draggedID + key.substring(swappedID.length)] = tempData[key];
+                    }
+                })
+            }
+        }
+    });
+
+    NewSortableSwapContainer(subMemberList, "button", "", function(e){
+        // Disable swapping for character grid-inputs that are not filled
+        // This is necessary to avoid a bug where the Wikitext duplicates a character if moved to an empty grid slot
+        const target = e.related;
+
+        if (!teamData[target.id]) {
+            return false;
+        }
+
+        return true
+    }, function(e) {
+        if (e.oldIndex != e.newIndex) {
+            const draggedElement = e.item
+            let swappedElement
+            
+            if (e.newIndex == 0) {
+                swappedElement = document.querySelector("#char4")
+            }
+
+            if (e.newIndex == 1) {
+                swappedElement = document.querySelector("#char5")
+            }
+
+            const draggedID = draggedElement.id;
+            const swappedID = swappedElement.id;
+
+            // Swap IDs
+            draggedElement.id = swappedID;
+            swappedElement.id = draggedID;
+
+            if (teamData[draggedID]) {
+                const tempData = {...teamData}
+                Object.keys(teamData).forEach(key => {
+                    // Find all keys that start with dragged character's ID (ex: char1)
+                    if (key.startsWith(draggedID)) {
+                    // Swap the dragged character's data with the swapped character's data
+                        teamData[swappedID + key.substring(draggedID.length)] = tempData[key]
+                    }
+
+                    // Find all keys that start with swapped character's ID (ex: char1)
+                    if (key.startsWith(swappedID)) {
+                        // Swap the swapped character's data with the dragged character's data
+                        teamData[draggedID + key.substring(swappedID.length)] = tempData[key];
+                    }
+                })
+            }
+        }
+    });
+}

--- a/sortable.js
+++ b/sortable.js
@@ -1,9 +1,10 @@
-function NewSortableSwapContainer(container, draggable, onMove, onEnd) {
+function NewSortableSwapContainer(container, draggable, onMove, onEnd, extraOptions={}) {
     return new Sortable(container, {
         swap: true,
         animation: 150,
         ghostClass: "sortable-ghost",
         draggable: draggable,
+        ...extraOptions,
         onMove: (e) => {
             return onMove(e);
         },
@@ -137,15 +138,15 @@ function InitSummonsContainer() {
             if (teamData[draggedID]) {
                 const tempData = {...teamData}
                 Object.keys(teamData).forEach(key => {
-                    // Find all keys that start with dragged character's ID (ex: char1)
+                    // Find all keys that start with dragged summon's ID (ex: s1)
                     if (key.startsWith(draggedID)) {
-                    // Swap the dragged character's data with the swapped character's data
+                    // Swap the dragged summon's data with the swapped summon's data
                         teamData[swappedID + key.substring(draggedID.length)] = tempData[key]
                     }
 
-                    // Find all keys that start with swapped character's ID (ex: char1)
+                    // Find all keys that start with swapped summon's ID (ex: s1)
                     if (key.startsWith(swappedID)) {
-                        // Swap the swapped character's data with the dragged character's data
+                        // Swap the swapped summon's data with the dragged summon's data
                         teamData[draggedID + key.substring(swappedID.length)] = tempData[key];
                     }
                 })
@@ -186,19 +187,132 @@ function InitSummonsContainer() {
             if (teamData[draggedID]) {
                 const tempData = {...teamData}
                 Object.keys(teamData).forEach(key => {
-                    // Find all keys that start with dragged character's ID (ex: char1)
+                    // Find all keys that start with dragged summon's ID (ex: s1)
                     if (key.startsWith(draggedID)) {
-                    // Swap the dragged character's data with the swapped character's data
+                    // Swap the dragged summon's data with the swapped summon's data
                         teamData[swappedID + key.substring(draggedID.length)] = tempData[key]
                     }
 
-                    // Find all keys that start with swapped character's ID (ex: char1)
+                    // Find all keys that start with swapped summon's ID (ex: s1)
                     if (key.startsWith(swappedID)) {
-                        // Swap the swapped character's data with the dragged character's data
+                        // Swap the swapped summon's data with the dragged summon's data
                         teamData[draggedID + key.substring(swappedID.length)] = tempData[key];
                     }
                 })
             }
         }
     });
+}
+
+function InitWeaponsContainer() {
+    const weaponsList = document.querySelector("#weapon-grid .w-grid-sub");
+    const extraWeaponsList = document.querySelector("#weapon-grid-extra .w-grid-sub");
+
+    NewSortableSwapContainer(weaponsList, "div", function(e) {
+        // Disable swapping for weapon grid-inputs that are not filled
+        // This is necessary to avoid a bug where the Wikitext duplicates a weapon if moved to an empty grid slot
+        const target = e.related;
+        const trimmedID = target.id[target.id.length - 1]
+
+        if (!teamData[`wp${trimmedID}`]) {
+            return false;
+        }
+
+        return true
+    }, function(e) {
+        if (e.oldIndex != e.newIndex) {
+            const draggedElement = e.item
+            const swappedElement = document.querySelector(`#slot${e.newIndex + 1}`)
+
+            const draggedID = draggedElement.id;
+            const swappedID = swappedElement.id;
+            const draggedButton = document.querySelector(`#${draggedID} button`);
+            const swappedButton = document.querySelector(`#${swappedID} button`);
+
+            // Swap container IDs
+            draggedElement.id = swappedID;
+            swappedElement.id = draggedID;
+
+            // Swap button IDs
+            draggedButton.id = `wp${swappedID[swappedID.length - 1]}`
+            swappedButton.id = `wp${draggedID[draggedID.length - 1]}`
+
+            if (teamData[draggedButton.id]) {
+                const tempData = {...teamData}
+                Object.keys(teamData).forEach(key => {
+                    // Find all keys that start with dragged weapon's ID (ex: wp1)
+                    if (key.startsWith(draggedButton.id)) {
+                    // Swap the dragged weapon's data with the swapped weapon's data
+                        teamData[swappedButton.id + key.substring(draggedButton.id.length)] = tempData[key]
+                    }
+
+                    // Find all keys that start with swapped weapon's ID (ex: wp1)
+                    if (key.startsWith(swappedButton.id)) {
+                        // Swap the swapped weapon's data with the dragged weapon's data
+                        teamData[draggedButton.id + key.substring(swappedButton.id.length)] = tempData[key];
+                    }
+                })
+            }
+        }
+    }, { handle: ".grid-input", });
+    
+    NewSortableSwapContainer(extraWeaponsList, "div", function(e) {
+        // Disable swapping for weapon grid-inputs that are not filled
+        // This is necessary to avoid a bug where the Wikitext duplicates a weapon if moved to an empty grid slot
+        const target = e.related;
+        const trimmedID = target.id.slice(-2) // Last two characters (10, 11, 12)
+
+        if (!teamData[`wp${trimmedID}`]) {
+            return false;
+        }
+
+        return true
+    }, function(e) {
+        if (e.oldIndex != e.newIndex) {
+            const draggedElement = e.item
+            let swappedElement
+
+             if (e.newIndex == 0) {
+                swappedElement = document.querySelector("#slot10")
+            }
+
+            if (e.newIndex == 1) {
+                swappedElement = document.querySelector("#slot11")
+            }
+
+             if (e.newIndex == 2) {
+                swappedElement = document.querySelector("#slot12")
+            }
+
+            const draggedID = draggedElement.id;
+            const swappedID = swappedElement.id;
+            const draggedButton = document.querySelector(`#${draggedID} button`);
+            const swappedButton = document.querySelector(`#${swappedID} button`);
+
+            // Swap container IDs
+            draggedElement.id = swappedID;
+            swappedElement.id = draggedID;
+
+            // Swap button IDs
+            draggedButton.id = `wp${swappedID.slice(-2)}`
+            swappedButton.id = `wp${draggedID.slice(-2)}`
+
+            if (teamData[draggedButton.id]) {
+                const tempData = {...teamData}
+                Object.keys(teamData).forEach(key => {
+                    // Find all keys that start with dragged weapon's ID (ex: wp1)
+                    if (key.startsWith(draggedButton.id)) {
+                    // Swap the dragged weapon's data with the swapped weapon's data
+                        teamData[swappedButton.id + key.substring(draggedButton.id.length)] = tempData[key]
+                    }
+
+                    // Find all keys that start with swapped weapon's ID (ex: wp1)
+                    if (key.startsWith(swappedButton.id)) {
+                        // Swap the swapped weapon's data with the dragged weapon's data
+                        teamData[draggedButton.id + key.substring(swappedButton.id.length)] = tempData[key];
+                    }
+                })
+            }
+        }
+    }, { handle: ".grid-input", });
 }

--- a/styles.css
+++ b/styles.css
@@ -475,3 +475,7 @@ ul {
 li.active {
     background-color: #d3d3d3;
 }
+
+.sortable-ghost {
+    opacity: 0.4;
+}


### PR DESCRIPTION
Made the team slots, weapon grid slots, and summon slots all draggable as per this section in the TODO:

```Markdown
- Drag rearrange
  - mousedown should store the target button and mouseup should check the stored value. if the value is the same treat it as a click, otherwise if the buttons share the same optionset treat it as a swap, otherwise ignore it. all appriopriate data for each swapped item should be updated in the teamData object (Uncap, Trans, Awk, etc).
```